### PR TITLE
fix for ofGetTargetPlatform on armv7

### DIFF
--- a/libs/openFrameworks/utils/ofUtils.cpp
+++ b/libs/openFrameworks/utils/ofUtils.cpp
@@ -801,8 +801,8 @@ ofTargetPlatform ofGetTargetPlatform(){
         return OF_TARGET_LINUX64;
     } else if(ofIsStringInString(arch,"armv6l")) {
         return OF_TARGET_LINUXARMV6L;
-    } else if(ofIsStringInString(arch,"armv6l")) {
-        return OF_TARGET_LINUXARMV6L;
+    } else if(ofIsStringInString(arch,"armv7l")) {
+        return OF_TARGET_LINUXARMV7L;
     } else {
         return OF_TARGET_LINUX;
     }


### PR DESCRIPTION
ofGetTargetPlatform incorrectly returns OF_TARGET_LINUX instead of OF_TARGET_LINUXARMV7L. There seems to have been made a typo or merge error here:

https://github.com/openframeworks/openFrameworks/commit/ac39926447e24f18636811895eabdb5216cb3446
Note the double check for 'armv6l'
