### PR TITLE
App does not exit on SIGINT or SIGTERM

### DIFF
--- a/libs/openFrameworks/app/ofAppEGLWindow.cpp
+++ b/libs/openFrameworks/app/ofAppEGLWindow.cpp
@@ -308,6 +308,13 @@ EGLint ofAppEGLWindow::getEglVersionMinor() const {
 }
 
 //------------------------------------------------------------
+#ifdef TARGET_SUNXI_MFB
+  void ofAppEGLWindow::endInfinitLoop() {
+    terminate = true;
+  }
+#endif
+
+//------------------------------------------------------------
 void ofAppEGLWindow::init(Settings _settings) {
     terminate      = false;
 

--- a/libs/openFrameworks/app/ofAppEGLWindow.h
+++ b/libs/openFrameworks/app/ofAppEGLWindow.h
@@ -143,6 +143,9 @@ public:
 	EGLint getEglVersionMajor () const;
 	EGLint getEglVersionMinor() const;
 
+#ifdef TARGET_SUNXI_MFB
+	void endInfinitLoop();
+#endif
 
 protected:
 	void init(Settings settings = Settings());

--- a/libs/openFrameworks/app/ofAppRunner.cpp
+++ b/libs/openFrameworks/app/ofAppRunner.cpp
@@ -67,7 +67,11 @@ void ofExitCallback();
 		ofLogVerbose("ofAppRunner") << "sighandler caught: " << sig;
 		if(!bExitCalled) {
 			bExitCalled = true;
-			exitApp();
+			#ifndef TARGET_SUNXI_MFB
+				exitApp();
+			#else
+				static_cast<ofAppEGLWindow*>(window.get())->endInfinitLoop();
+			#endif
 		}
 	}
 #endif


### PR DESCRIPTION
Compiled apps do not exit cleanly when sent a SIGINT (eg Ctrl-c from ssh) or SIGTERM (eg kill from ssh). Pressing the Esc key on the console (usb keyboard) does exit the app cleanly. Stuck apps can be force-quit with SIGKILL (eg kill -9 from ssh)

The app gets stuck in ofAppEGLWindow::destroySurface() on the call to eglDestroySurface(eglDisplay, eglSurface); Unfortunately, this lands us into binary blob territory which we cannot fix.

This patch works around the issue by not using exitApp() directly and mid-frame, but instead signalling ofAppEGLWindow::runAppViaInfiniteLoop to gracefully end the loop. This seems to work more reliably than using exitApp() in the middle of frame execution.

Exiting the app using the Esc key on an external keyboard is unchanged, as is using exitApp() from code.
